### PR TITLE
add quick init option

### DIFF
--- a/bin/mean-init
+++ b/bin/mean-init
@@ -10,14 +10,14 @@ program
   .option('-b, --branch <branch>', 'git branch')
   .option('-g, --git', 'clone using git:// instead of https://')
   .option('--repo <repo>', 'Specify repository to install')
-  .option('-f, --force', 'force')
+  .option('-q, --quick', 'Automatically go into the directory, run npm install and grunt')
   .parse(process.argv);
 
 var options = {
   branch: program.branch || 'master',
   git: program.git,
   repo: program.repo,
-  force: program.force
+  quick: program.quick
 };
 
 cli.init(program.args.length ? program.args[0] : 'mean', options);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -162,12 +162,31 @@ exports.init = function(name, options) {
       fs.readFile(__dirname + '/../img/logo.txt', function(err, data) {
         console.log(data.toString());
         console.log();
-        console.log('   install dependencies:');
-        console.log('     $ cd %s && npm install', name);
-        console.log();
-        console.log('   run the app:');
-        console.log('     $ grunt');
-        console.log();
+        if (options.quick) {
+          shell.cd(name);
+          npm.load(function(err, npm) {
+            console.log(chalk.green('   installing dependencies...'));
+            console.log();
+            npm.commands.install(function(err) {
+              if (err) {
+                console.log(chalk.red('Error: npm install failed'));
+                return console.error(err);
+              }
+              console.log(chalk.green('   running the mean app...'));
+              console.log();
+              if (shell.which('grunt')) {
+                shell.exec('grunt', ['-f']);
+              }
+            });
+          });
+        } else {
+          console.log('   install dependencies:');
+          console.log('     $ cd %s && npm install', name);
+          console.log();
+          console.log('   run the app:');
+          console.log('     $ grunt');
+          console.log();
+        }
         console.log('   Extra Docs at http://mean.io');
       });
     });


### PR DESCRIPTION
Basically, this change would automatically do the `cd <myApp> && npm install` and the run `grunt` - all with a single command, namely `mean init -q <myApp>`. It would be GREAT for demos, but the concern is for newbs to run and report an issue. It might be harder to debug.

Additionally, the terminal is still at a directory level below, which might be confusing.
