### PR TITLE
uninstall for Custom packages

### DIFF
--- a/bin/mean
+++ b/bin/mean
@@ -13,7 +13,7 @@ program.version(version, '-v, --version');
 program
   .command('init <name> [options]', 'Create a MEAN application in the current working directory')
   .command('install <module> [options]', 'Installs a MEAN module')
-  .command('uninstall <module>', 'Uninstalls a MEAN module')
+  .command('uninstall <module>', 'Uninstalls a MEAN package or module')
   .command('docs', 'Opens MEAN documentation in your local browser')
   .command('package <name> [options]', 'package')
   .command('list', 'List all installed packages')

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -66,6 +66,7 @@ function ensureEmpty(path, force, callback) {
 }
 
 function getPackageInfo(type, data) {
+  if (!data) return;
   var author = data.author ? chalk.green('  Author: ') + data.author.name : '';
   return chalk.green('   ' + type + ': ') + data.name + '@' + data.version + author;
 }
@@ -234,17 +235,23 @@ exports.install = function(module, options) {
 
 exports.uninstall = function(module) {
   requiresRoot(function() {
-    console.log(chalk.yellow('Removing module:'), module);
 
-    npm.load(function(err, npm) {
-      npm.commands.uninstall([module], function(err) {
-        if (err) {
-          console.log(chalk.red('Error: npm install failed'));
-          return console.error(err);
-        }
-        console.log(chalk.green('   npm uninstall complete'));
+    // uninstall local packages first
+    if (fs.existsSync('./packages/' + module)) {
+      console.log(chalk.yellow('Removing Custom package:'), module);
+      shell.rm('-rf', './packages/' + module);
+    } else {
+      console.log(chalk.yellow('Removing Contrib package:'), module);
+      npm.load(function(err, npm) {
+        npm.commands.uninstall([module], function(err) {
+          if (err) {
+            console.log(chalk.red('Error: npm install failed'));
+            return console.error(err);
+          }
+          console.log(chalk.green('   npm uninstall complete'));
+        });
       });
-    });
+    }
   });
 };
 
@@ -260,16 +267,16 @@ exports.list = function() {
         if (err || !files.length) return console.log(chalk.yellow('   No ' + type + ' Packages'));
         files.forEach(function(file) {
           loadPackageJson(path + file + '/package.json', function(err, data) {
-            if (!err && data.mean) console.log(getPackageInfo(data));
+            if (!err && data.mean) console.log(getPackageInfo(type, data));
           });
         });
       });
     }
 
-    //look in node_modules for external packages
+    // look in node_modules for external packages
     look(pkgType.contrib);
 
-    //look in packages for local modules
+    // look in packages for local packages
     look(pkgType.custom);
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meanio",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "preferGlobal": true,
   "description": "Simple command line interface for installing and managing MEAN apps",
   "author": {


### PR DESCRIPTION
Enable uninstall (deletion) of Custom packages. If Custom package exists with same name as Contrib package, Custom will be removed first.
