### PR TITLE
Option to remove a custom package

### DIFF
--- a/bin/mean-package
+++ b/bin/mean-package
@@ -7,6 +7,7 @@ var cli = require('../lib/cli'),
 
 program
   .description('Scaffolds a new MEAN package.')
+  .option('-d, --delete', 'delete')
   .option('-f, --force', 'force')
   .parse(process.argv);
 
@@ -16,6 +17,7 @@ if (!program.args.length) {
 }
 
 var options = {
+  delete: program.delete,
   force: program.force
 };
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -66,6 +66,7 @@ function ensureEmpty(path, force, callback) {
 }
 
 function getPackageInfo(type, data) {
+  if (!data) return;
   var author = data.author ? chalk.green('  Author: ') + data.author.name : '';
   return chalk.green('   ' + type + ': ') + data.name + '@' + data.version + author;
 }
@@ -260,16 +261,16 @@ exports.list = function() {
         if (err || !files.length) return console.log(chalk.yellow('   No ' + type + ' Packages'));
         files.forEach(function(file) {
           loadPackageJson(path + file + '/package.json', function(err, data) {
-            if (!err && data.mean) console.log(getPackageInfo(data));
+            if (!err && data.mean) console.log(getPackageInfo(type, data));
           });
         });
       });
     }
 
-    //look in node_modules for external packages
+    // look in node_modules for external packages
     look(pkgType.contrib);
 
-    //look in packages for local modules
+    // look in packages for local packages
     look(pkgType.custom);
   });
 };
@@ -294,9 +295,14 @@ exports.status = function(options) {
 
 exports.pkg = function(name, options) {
   requiresRoot(function() {
-    ensureEmpty('./packages/' + name, options.force, function() {
-      require('./scaffold.js').packages(name, options);
-    });
+    if (options.delete) {
+      console.log(chalk.yellow('Removing package:'), name);
+      shell.rm('-rf', './packages/' + name);
+    } else {
+      ensureEmpty('./packages/' + name, options.force, function() {
+        require('./scaffold.js').packages(name, options);
+      });
+    }
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meanio",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "preferGlobal": true,
   "description": "Simple command line interface for installing and managing MEAN apps",
   "author": {


### PR DESCRIPTION
Enable deletion of Custom packages via `-d` option, similar to `git branch -d`.

Originally added deletion of custom packages to `uninstall` command, but considering separation of concerns, I think this is a better approach.
