### PR TITLE
Testing if filenames for aggregation *end with* .ext

### DIFF
--- a/lib/mean.js
+++ b/lib/mean.js
@@ -266,7 +266,7 @@ function aggregate(ext, path) {
 	function readFile(ext, path) {
 		fs.readdir(path, function(err, files) {
 			if (files) return readFiles(ext, path + '/');
-			if (path.indexOf('.' + ext) == -1) return;
+			if (path.indexOf('.' + ext) !== path.length-ext.length-1) return;
 			fs.readFile(path, function(fileErr, data) {
 				//add some exists and refactor
 				//if (fileErr) console.log(fileErr)

--- a/lib/mean0.3.1.js
+++ b/lib/mean0.3.1.js
@@ -264,7 +264,7 @@ function aggregate(ext, path, options) {
 	function readFile(ext, path) {
 		fs.readdir(path, function(err, files) {
 			if (files) return readFiles(ext, path + '/');
-			if (path.indexOf('.' + ext) == -1) return;
+			if (path.indexOf('.' + ext) !== path.length-ext.length-1) return;
 			fs.readFile(path, function(fileErr, data) {
 				//add some exists and refactor
 				//if (fileErr) console.log(fileErr)

--- a/lib/mean0.3.2.js
+++ b/lib/mean0.3.2.js
@@ -318,7 +318,7 @@ function aggregate(ext, path, options) {
 	function readFile(ext, path) {
 		fs.readdir(path, function(err, files) {
 			if (files) return readFiles(ext, path + '/');
-			if (path.indexOf('.' + ext) === -1) return;
+			if (path.indexOf('.' + ext) !== path.length-ext.length-1) return;
 			fs.readFile(path, function(fileErr, data) {
 				//add some exists and refactor
 				//if (fileErr) console.log(fileErr)


### PR DESCRIPTION
During aggregation, original code picks up all file names that contain '.'+ext. During development, directories may contain backup files, .swp files etc. These files will make into aggregated code. During development, if you use vim as an editor, aggregated code will pick up .swp files as well (.filename.js.swp) which leads to erroneous aggregated code.
Proposed change leads to aggregation picking up only file names that _end_ with '.'+ext. Problem resolved.
