### PR TITLE
2 fixes in file handling

### DIFF
--- a/lib/mean0.3.2.js
+++ b/lib/mean0.3.2.js
@@ -302,7 +302,7 @@ function aggregate(ext, aggPath, options) {
 			if (err) return;
 			files.forEach(function(file) {
 				if (!libs && file !== 'assets') {
-					readFile(ext, filepath + file);
+					readFile(ext, path.join(filepath, file));
 				}
 			});
 		});
@@ -311,7 +311,7 @@ function aggregate(ext, aggPath, options) {
 	function readFile(ext, filepath) {
 		fs.readdir(filepath, function(err, files) {
 			if (files) return readFiles(ext, filepath);
-			if (path.extname(filepath) === '.' + ext) return;
+			if (path.extname(filepath) !== '.' + ext) return;
 			fs.readFile(filepath, function(fileErr, data) {
 				//add some exists and refactor
 				//if (fileErr) console.log(fileErr)


### PR DESCRIPTION
1. filepath may not contain a slash at the end (on amazon-linux, ext4 I get this situation). Without digging deeper into this matter, one should simply use path.join instead of string concatenation
2. aggregation actually does exactly the opposite without this patch. Only files that _do not_ match the extension make it into the aggregated[ext]
