### PR TITLE
adding 'generateAggregate' method

### DIFF
--- a/lib/mean.js
+++ b/lib/mean.js
@@ -284,15 +284,15 @@ function registerAggregateAsset(ext, aggPath) {
     if (!registeredAssets[ext]) { registeredAssets[ext] = []; }
     // register trusted path
     registeredAssets[ext].push(aggPath);
-    console.log('registered new asset: ' + aggPath);
+    //console.log('registered new asset: ' + aggPath);
 }
 
 function isRegisteredAsset(ext, path) {
-    console.log('trying to find asset: ' + path);
+    //console.log('trying to find asset: ' + path);
     for (var i = registeredAssets[ext].length - 1; i >= 0; i--) {
         if (path === registeredAssets[ext][i]) { return true; }
     }
-    console.log('NOT FOUND');
+    //console.log('NOT FOUND');
     return false;
 }
 


### PR DESCRIPTION
- enable aggregate.js/css files to be generated fresh
- support sending generated string to through callback

This change will enable live reload of changes to *.js and *.css files in packages by changing https://github.com/linnovate/mean/blob/master/server/config/express.js#L115 to:

```
        mean.generateAggregate('js', (process.env.NODE_ENV ===
'production'), function(s){
            res.send(s);
        });
```

Instead of:

```
        res.send(mean.aggregated.js);
```
