### PR TITLE
Is the extra " exports = " needed?

### DIFF
--- a/lib/mean.js
+++ b/lib/mean.js
@@ -597,4 +597,4 @@ Meanio.prototype.chainware = {
     }
 };
 
-module.exports = exports = new Meanio();
+module.exports = new Meanio();


### PR DESCRIPTION
Webstorm was flagging this extra " = exports" in this library? Is this needed? I removed it and the code seems to run fine and all my local tests still pass.

module.exports = exports = new Meanio();
module.exports = new Meanio();
