### PR TITLE
adding http.Server object as Mean.server

### DIFF
--- a/lib/mean.js
+++ b/lib/mean.js
@@ -71,9 +71,8 @@ Meanio.prototype.serve = function(options, callback) {
     Mean.config = new Config(function(err, config) {
       // Bootstrap Models, Dependencies, Routes and the app as an express app
       var app = require('./bootstrap')(options, database);
-
       // Start the app by listening on <port>, optional hostname
-      app.listen(config.port, config.hostname);
+      var server = app.listen(config.port, config.hostname);
 
       findModules(function() {
         enableModules();
@@ -83,6 +82,7 @@ Meanio.prototype.serve = function(options, callback) {
 
       Mean.name = config.app.name;
       Mean.app = app;
+      Mean.server = server;
 
       menus = new Mean.Menus();
       Mean.menus = menus;


### PR DESCRIPTION
If some modules requires naive http.Server, it should be exposed in a callback function of mean.serve().
For example, in socket.io, http://socket.io/docs/#using-with-express-3/4.

I make new pull request becuase of my mistake. Sorry! #18
