### PR TITLE
Options for mongoose connect

### DIFF
--- a/lib/mean.js
+++ b/lib/mean.js
@@ -57,7 +57,7 @@ Meanio.prototype.serve = function(options, callback) {
   // Initializing system variables
   var defaultConfig = util.loadConfig();
 
-  var database = mongoose.connect(defaultConfig.db || '', function(err) {
+  var database = mongoose.connect(defaultConfig.db || '', defaultConfig.dbOptions || {}, function(err) {
     if (err) {
       console.error('Error:', err.message);
       return console.error('**Could not connect to MongoDB. Please ensure mongod is running and restart MEAN app.**');


### PR DESCRIPTION
There are various setup options mongoose can take and there is currently no way to pass those to mongoose. I added ability to pass in options to the mongoose connect in `mean.serve()` with a key called `dbOptions` that can be added in the configuration files for a MEAN project. Is this an acceptable solution?
