### PR TITLE
Refactored mongoose.connect for new db config object

### DIFF
--- a/lib/mean.js
+++ b/lib/mean.js
@@ -60,9 +60,12 @@ Meanio.prototype.serve = function(options, callback) {
   // Initializing system variables
   var defaultConfig = util.loadConfig();
 
-  mongoose.set('debug', defaultConfig.mongoose && defaultConfig.mongoose.debug);
+  mongoose.set('debug', !!defaultConfig.db.debug);
 
-  var database = mongoose.connect(defaultConfig.db || '', defaultConfig.dbOptions || {}, function(err) {
+  //Checks if they have only put in a string for the db connection
+  var connectionUrl = (typeof defaultConfig.db === 'string')? defaultConfig.db : defaultConfig.db.url;
+
+  var database = mongoose.connect(connectionUrl || '', defaultConfig.db.options || {}, function(err) {
     if (err) {
       console.error('Error:', err.message);
       return console.error('**Could not connect to MongoDB. Please ensure mongod is running and restart MEAN app.**');


### PR DESCRIPTION
Changed the mongoose connect setup to use the new integrated `db` object mentioned [here](https://github.com/linnovate/mean/pull/737)
