### PR TITLE
Fixing typo in prototype.aggregateAsset

### DIFF
--- a/lib/mean.js
+++ b/lib/mean.js
@@ -338,7 +338,7 @@ Module.prototype.angularDependencies = function(dependencies) {
   modules[this.name].angularDependencies = dependencies;
 };
 
-Module.prototypeaggregateAsset = function(type, asset, options) {
+Module.prototype.aggregateAsset = function(type, asset, options) {
   options = options || {};
   asset = options.inline ? asset : (options.absolute ? asset : path.join(modules[this.name].source, this.name, 'public/assets', type, asset));
   aggregate(type, asset, options);


### PR DESCRIPTION
Typo keeps prevents assets being aggregated.
