### PR TITLE
Remove duplicate call to npm outdated

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -117,25 +117,6 @@ function checkVersion() {
       }
     });
   });
-
-  npm.load({
-    global: true,
-    loglevel: 'warn'
-  }, function(err, npm) {
-    npm.commands.outdated('mean-cli', true, function(err, list) {
-      if (err) {
-        console.log(chalk.red('Error: npm outdated failed'));
-        return console.error(err);
-      }
-      latest = list[0] ? list[0][3] : cliVersion; // list[0][3] holds the 'latest' value
-      if (latest < cliVersion) {
-        console.log(chalk.yellow('    mean-cli is out of date'));
-        console.log('    Current: ' + cliVersion + ' Latest: ' + latest);
-      } else {
-        console.log(chalk.green('    mean-cli at latest version:'), cliVersion);
-      }
-    });
-  });
 }
 
 function requiresRoot(callback) {


### PR DESCRIPTION
The mean status call breaks due to the duplicate call as the list param returns empty the second time. This fixes the TypeError: Cannot read property '3' of undefined error when doing mean status

Full stack trace 
TypeError: Cannot read property '3' of undefined
    at /usr/local/lib/node_modules/mean-cli/lib/cli.js:134:21
    at /usr/local/lib/node_modules/mean-cli/node_modules/npm/lib/outdated.js:42:51
    at cb (/usr/local/lib/node_modules/mean-cli/node_modules/npm/node_modules/slide/lib/async-map.js:48:11)
    at cb (/usr/local/lib/node_modules/mean-cli/node_modules/npm/node_modules/slide/lib/async-map.js:48:11)
    at cb (/usr/local/lib/node_modules/mean-cli/node_modules/npm/node_modules/slide/lib/async-map.js:48:11)
    at cb (/usr/local/lib/node_modules/mean-cli/node_modules/npm/node_modules/slide/lib/async-map.js:48:11)
    at asyncMap (/usr/local/lib/node_modules/mean-cli/node_modules/npm/node_modules/slide/lib/async-map.js:27:18)
    at next (/usr/local/lib/node_modules/mean-cli/node_modules/npm/lib/outdated.js:235:5)
    at /usr/local/lib/node_modules/mean-cli/node_modules/npm/lib/outdated.js:198:14
    at ReaddirReq.Req.done (/usr/local/lib/node_modules/mean-cli/node_modules/npm/node_modules/graceful-fs/graceful-fs.js:141:5)
