### PR TITLE
Fix for preinstall script error on windows.

### DIFF
--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -15,7 +15,8 @@ if (~args.indexOf('meanio') && ~args.indexOf('--global')) {
   process.exit(1);
 } else if (~args.indexOf('mean-cli')) {
   var spawn = require('child_process').spawn,
-    npmls = spawn('npm', ['ls', '--global', '--json', '--depth', '0']);
+  	npm = (process.platform === "win32" ? "npm.cmd" : "npm"),
+    npmls = spawn(npm, ['ls', '--global', '--json', '--depth', '0']);
 
   var data = {};
   npmls.stdout.on('data', function(d) {


### PR DESCRIPTION
Running `npm i -g mean-cli` on windows would cause an error on events.js line 72, this should fix the issue.

From http://stackoverflow.com/questions/17516772/using-nodejss-spawn-causes-unknown-option-and-error-spawn-enoent-err
