### PR TITLE
Running bower install and bower update at the same time is bad

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -805,9 +805,6 @@ exports.postinstall = function() {
   requiresRoot(function() {
     var bower = require('bower');
     console.log(chalk.green('Installing Bower dependencies'));
-    bower.commands.install().on('error', function(err) {
-      console.log(chalk.red(err));
-    });
     bower.commands.update().on('error', function(err) {
       console.log(chalk.red(err));
     });


### PR DESCRIPTION
Turns out running bower install and bower update at the same time causes weird things to happen. Also turns out we don't need both, update() runs install all on it's own. This should resolve some errors I've been seeing
