### PR TITLE
Support projects with spaces

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -889,7 +889,7 @@ exports.init = function(options) {
   console.log(chalk.green('Cloning branch: %s into destination folder:'), options.branch, name);
 
   progress.start();
-  source = options.branch + ' ' + source + ' ' + name;
+  source = options.branch + ' ' + source + ' "' + name + '"';
   shell.exec('git clone -b ' + source, function(code, output) {
     progress.stop();
     if (code) return console.log(chalk.red('Error: git clone failed:', output));


### PR DESCRIPTION
Added quotes around name of project when cloning so it supports projects with spaces. Ran into this issue on Windows and needed to fix it, will help others if they run into the same issue.