### PR TITLE
Use name param in correct place. Fixes #100

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -103,13 +103,13 @@ function checkoutStableTag(name){
 
 function nextSteps(name) {
   console.log('  Install node package dependencies:');
-  console.log('    $ ' + chalk.green('cd %s && npm install', name));
+  console.log('    $ ' + chalk.green('cd %s && npm install'), name);
   console.log('  Bower install should be triggered for client side dependencies.');
   console.log('  If it did not run invoke it manually...');
-  console.log('    $ ' + chalk.green('cd %s && bower install', name));
+  console.log('    $ ' + chalk.green('cd %s && bower install'), name);
   console.log();
   console.log('  Run the app by running:');
-  console.log('    $ ' + chalk.green('cd ' + name + ' and then run..'));
+  console.log('    $ ' + chalk.green('cd %s and then run..'), name);
   console.log('    $ '+ chalk.green('gulp'));
   console.log();
 }


### PR DESCRIPTION
The name parameter was used in incorrect place within a code. And because Chalk
module does not support string replacement incorrectly replaced text strings were
shown to users during installation. To fix problems the name parameter is used
as argument to Console.log

After change the output strings are correctly rendered:
![20150326213400](https://cloud.githubusercontent.com/assets/14539/6856422/516b6d8e-d400-11e4-8961-6924972111df.jpg)
