### PR TITLE
throw removed on a badly implemented idea

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -64,7 +64,6 @@ exports.checkNpmPermission = function (callback){
     if (hasRootFiles > 1){
       console.log (chalk.red('There are ' + hasRootFiles + ' files in your ~/.npm owned by root'));
       console.log(chalk.green('Please change the permissions by running -'), 'chown -R `whoami` ~/.npm ');
-      throw('ROOT PERMISSIONS IN NPM');
     }
   });
   callback();


### PR DESCRIPTION
Remove throw and just log the "problem". 
Badly implemented idea to check npm for permissions.
On my Windows system, I do not have a %USERPROFILE%/.npm and the installation get's thrown.
On other non-Windows systems, I also do not have $HOME/.npm so the Whole idea of the test is a bit in question.
throw removed as a suggestion, but the Whole idea of the check is in question
