### PR TITLE
undefined callback causing mean-init to crash

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -67,5 +67,7 @@ exports.checkNpmPermission = function (callback){
       throw('ROOT PERMISSIONS IN NPM');
     }
   });
-  callback();
+  if (callback !== undefined) {
+    callback();
+  }
 };


### PR DESCRIPTION
I was getting the following crash whenever running mean-init. This seems to fix the issue. There is a callback that is executed, but it is not being set by the calling function.

```
$ mean-init app
? What would you name your mean app? app

/usr/lib/node_modules/mean-cli/node_modules/inquirer/node_modules/rx/dist/rx.js:579
    throw e;
          ^
TypeError: undefined is not a function
    at Object.exports.checkNpmPermission (/usr/lib/node_modules/mean-cli/lib/utils.js:70:3)
    at Array.checkPermissions [as 0] (/usr/lib/node_modules/mean-cli/lib/install.js:36:11)
    at handleItem (/usr/lib/node_modules/mean-cli/node_modules/async-series/index.js:14:13)
    at series (/usr/lib/node_modules/mean-cli/node_modules/async-series/index.js:30:3)
    at Object.exports.init (/usr/lib/node_modules/mean-cli/lib/install.js:14:3)
    at exports.init (/usr/lib/node_modules/mean-cli/lib/cli.js:836:11)
    at PromptUI.completed (/usr/lib/node_modules/mean-cli/lib/wizard.js:43:5)
    at PromptUI.onCompletion (/usr/lib/node_modules/mean-cli/node_modules/inquirer/lib/ui/prompt.js:69:10)
    at AnonymousObserver.Rx.AnonymousObserver.AnonymousObserver.completed (/usr/lib/node_modules/mean-cli/node_modules/inquirer/node_modules/rx/dist/rx.js:1977:12)
    at AnonymousObserver.Rx.internals.AbstractObserver.AbstractObserver.onCompleted (/usr/lib/node_modules/mean-cli/node_modules/inquirer/node_modules/rx/dist/rx.js:1914:14)
```
