### PR TITLE
Fix install for nvm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ By "commiting" to this file, you ("you" or "You") hereby grant to Linnovate and 
 
 You, the contributor agree to the following…
 
-1. That you are the sole owner of the Contributions and/or have sufficient rights in your Contribution to grant all rights you grant hereunder. 
+1. That you are the sole owner of the Contributions and/or have sufficient rights in your Contribution to grant all rights you grant hereunder.
 1. That the Contributions are your original works of authorship.
 1. That you created the Contributions and did not copy them from another source, and no other person claims, or has the right to claim, any right in any invention or patent related to the Contributions.
 1. That you are legally entitled to grant the above license. (If your employer has rights to intellectual property that you create, you represent that you have received permission to make the Contributions on behalf of that employer, or that your employer has waived such rights for the Contributions.)
@@ -38,3 +38,4 @@ If you become aware of any facts or circumstances related to the representation 
 * Nedeljko Tadic {ntadic}
 * Jay Merrifield {fracmak}
 * Peter Blazejewicz {peterblazejewicz}
+* Jesse Snyder {steezeburger}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -58,7 +58,14 @@ exports.loadPackageJson = function(path, callback) {
 
 exports.checkNpmPermission = function (callback){
   var homeDir = process.env[isWin ? 'USERPROFILE' : 'HOME'];
-  var findCmd = 'find ' + homeDir +'/.npm ' + '-user root';
+  var findCmd = 'find ';
+  var whichNpm = shell.which('npm');
+  if (whichNpm.indexOf('/.nvm' > -1)) {
+    var whichNode = shell.which('node');
+    findCmd += whichNode + ' -user root';
+  } else {
+    findCmd = 'find ' + homeDir + '/.npm ' + '-user root';
+  }
   shell.exec(findCmd, function( status, output){
     var hasRootFiles = output.split(/\r\n|\r|\n/).length;
     if (hasRootFiles > 1){
@@ -175,6 +182,3 @@ exports.updateMeanJson = function(path , values, callback) {
         });
     });
 };
-
-
-

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -60,9 +60,9 @@ exports.checkNpmPermission = function (callback){
   var homeDir = process.env[isWin ? 'USERPROFILE' : 'HOME'];
   var findCmd = 'find ';
   var whichNpm = shell.which('npm');
-  if (whichNpm.indexOf('/.nvm' > -1)) {
+  if (whichNpm.indexOf('.nvm' > -1)) {
     var whichNode = shell.which('node');
-    findCmd += whichNode + ' -user root';
+    findCmd += whichNode.slice(0, -5) + '/npm -user root';
   } else {
     findCmd = 'find ' + homeDir + '/.npm ' + '-user root';
   }


### PR DESCRIPTION
`mean init foo` would fail when using NVM because there was no `~/.npm` folder.
Fixes #114 
