### PR TITLE
Fixes for 'mean package'

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -860,9 +860,9 @@ exports.pkg = function(name, options) {
   requiresRoot(function() {
     if (options.delete) {
       console.log(chalk.yellow('Removing package:'), name);
-      shell.rm('-rf', './packages/' + name);
+      shell.rm('-rf', './packages/custom/' + name);
     } else {
-      ensureEmpty('./packages/' + name, options.force, function() {
+      ensureEmpty('./packages/custom/' + name, options.force, function() {
         require('./scaffold.js').packages(name, options);
       });
     }

--- a/lib/scaffold.js
+++ b/lib/scaffold.js
@@ -11,11 +11,17 @@ function capitaliseFirstLetter(string) {
 }
 
 function camelCase(str) {
-  str = str.toLowerCase();
   var parts = str.split(/[\-_ \s]/);
-  str = null;
-  for (var i = 0; i < parts.length; i++) {
-    str = (str ? str + capitaliseFirstLetter(parts[i]) : parts[i]);
+  if(parts.length > 1) {
+    str = str.toLowerCase();
+    str = null;
+    for (var i = 0; i < parts.length; i++) {
+      str = (str ? str + capitaliseFirstLetter(parts[i]) : parts[i]);
+    }
+  }
+  else {
+    // Enforce lowerCamelCase if UpperCamelCase is input
+    str = str.charAt(0).toLowerCase() + str.slice(1);
   }
   return str;
 }
@@ -119,7 +125,7 @@ exports.packages = function(name, options) {
   var camelName = camelCase(name);
 
   data = {
-    pkgName: name.toLowerCase(),
+    pkgName: name,
     name: camelName,
     class: capitaliseFirstLetter(camelName),
     author: (typeof options.author === 'string' ? options.author : 'mean scaffold'),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mean-cli",
   "description": "Simple command line interface for installing and managing MEAN apps",
-  "version": "0.10.14",
+  "version": "0.10.15",
   "author": {
     "name": "https://github.com/linnovate/mean-cli/graphs/contributors"
   },


### PR DESCRIPTION
Fixes include:
Preserves name if input in camelCase i.e. 'myPackage'
Updated --delete for meanio 0.5.x directory structure